### PR TITLE
allow building with ghc-typelits-natnormalise 0.5

### DIFF
--- a/Data/Type/Natural/Builtin.hs
+++ b/Data/Type/Natural/Builtin.hs
@@ -263,7 +263,7 @@ toPeanoMonotone sn sm =
   case sn %~ (sing :: Sing 0) of
     Proved eql -> withRefl eql Refl
     Disproved nPos -> case sm %~ (sing :: Sing 0) of
-      Proved _ -> absurd $ nPos $ natLeqZero sn
+      Proved eql -> absurd $ nPos $ withRefl eql $ natLeqZero sn
       Disproved mPos ->
         let pn = sPred sn
             pm = sPred sm

--- a/type-natural.cabal
+++ b/type-natural.cabal
@@ -45,7 +45,7 @@ library
                      , monomorphic               >= 0.0.3
                      , template-haskell          >= 2.8     && < 3
                      , constraints               >= 0.3     && < 0.9
-                     , ghc-typelits-natnormalise == 0.4.*
+                     , ghc-typelits-natnormalise >= 0.4     && < 0.6
                      , ghc-typelits-presburger   >= 0.1.1   && < 1
                      , singletons                == 2.2.*
 


### PR DESCRIPTION
I have no idea why this makes a difference between 0.4 and 0.5 ghc-typelits-natnormlise. To be honest I'm not fully familiar with this kind of code.

But it looks like all that's needed to build with 0.5 is to bring the proof that m is zero into scope in the absurd case that n > 0  and m ~ 0 (when we're operating under the assumption that `(n <= m)`).